### PR TITLE
show course cards from discovery service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea
+.DS_Store

--- a/assets/css/discoveryCourseRunCards.css
+++ b/assets/css/discoveryCourseRunCards.css
@@ -1,0 +1,39 @@
+.course_card_container {
+    font-size: 0;
+}
+
+.course_card {
+    background: #E3F2FD;
+    border: 1px solid #64B5F6;
+    font-size: 16px;
+    padding: 15px;
+    margin-bottom: 30px;
+    display: inline-block;
+    margin-right: 15px;
+    width: calc(32% - 30px);
+    vertical-align: top;
+}
+
+.course_card:nth-child(3n) {
+    margin-right: 0;
+}
+
+.course_card p {
+    margin-bottom: 0;
+}
+
+.course_card p:nth-child(2) {
+    min-height: 62px;
+}
+
+.course_card p strong {
+    margin-bottom: 5px;
+    display: block;
+}
+
+@media (max-width: 767px) {
+    .course_card {
+        display: block;
+        width: 100%;
+    }
+}

--- a/assets/js/commons.min.js
+++ b/assets/js/commons.min.js
@@ -2,7 +2,9 @@
 window.ENEXT = window.ENEXT || {};
 
 ENEXT.OPENEDX_DOMAIN = ENEXT_SRV.lms_base_url;
+ENEXT.OPENEDX_DISCOVERY_DOMAIN = ENEXT_SRV.discovery_base_url;
 ENEXT.ENROLLMENT_API_LOCATION = ENEXT.OPENEDX_DOMAIN + ENEXT_SRV.enrollment_api_location;
+ENEXT.DISCOVERY_COURSE_RUNS_API_LOCATION = ENEXT.OPENEDX_DISCOVERY_DOMAIN + ENEXT_SRV.discovery_course_runs_api_location;
 
 ENEXT.getEnrollmentInfo = function() {
     var urlEnrollments = ENEXT.ENROLLMENT_API_LOCATION + 'enrollment';
@@ -20,6 +22,19 @@ ENEXT.getCourseData = function(courseID) {
     var urlCourse = ENEXT.ENROLLMENT_API_LOCATION + 'course/' + courseID + '?include_expired=1';
     return jQuery.ajax({
         url: urlCourse,
+        type: 'GET',
+        dataType: 'json',
+        xhrFields: {
+            withCredentials: true
+        }
+    });
+}
+
+ENEXT.getCourseRuns = function() {
+    var urlCourseRuns = ENEXT.DISCOVERY_COURSE_RUNS_API_LOCATION  + '?page_size=100';
+
+    return jQuery.ajax({
+        url: urlCourseRuns,
         type: 'GET',
         dataType: 'json',
         xhrFields: {

--- a/assets/js/discoveryCourseRunCards.min.js
+++ b/assets/js/discoveryCourseRunCards.min.js
@@ -1,0 +1,52 @@
+'use strict';
+window.ENEXT = window.ENEXT || {};
+ENEXT.registration = (function($) {
+
+    var BUTTONANCHORCLASS = '.discovery-course-runs-js';
+
+    var template = function(courseRunsData) {
+        let courseRunCards = ''
+        let courseCardsContainer = ''
+
+        courseRunsData.forEach(function(courseRun) {
+            courseRunCards = courseRunCards +
+                '<div class="course_card">' +
+                '<p><strong>Title: </strong>' + courseRun.title + '</p>' +
+                '<p><strong>Short Description: </strong>' + courseRun.short_description + '</p>' +
+                '<p><strong>Start: </strong>' + courseRun.start + '</p>' +
+                '</div>' +
+                '';
+        });
+
+        courseCardsContainer = '<div class="course_card_container">' + courseRunCards + '</div>';
+        return courseCardsContainer
+    }
+
+    var renderCourseRunCard = function(courseRunsData, $anchor) {
+        var settings = window[$anchor.data('settings')];
+        $anchor.show();
+        $anchor.html(template(courseRunsData));
+    }
+
+    var renderCards = function(courseRunsData, $anchor) {
+        renderCourseRunCard(courseRunsData, $anchor);
+    }
+
+    var init = function() {
+        ENEXT.getCourseRuns().always(function(data) {
+            // data.status only exists on error (e.g. its a jqXHR object)
+            var courseRunsData = data.status ? [] : data['results'];
+            $(BUTTONANCHORCLASS).each(function(index, elem) {
+                var $anchor = $(elem);
+                renderCards(courseRunsData, $anchor);
+            });
+        })
+    }
+
+    return {
+        init: init
+    }
+
+})(jQuery);
+
+ENEXT.registration.init();

--- a/includes/class-wp-edunext-marketing-site-settings.php
+++ b/includes/class-wp-edunext-marketing-site-settings.php
@@ -132,6 +132,14 @@ class WP_eduNEXT_Marketing_Site_Settings {
 					'placeholder'	=> __( 'https://mylms.edunext.io', 'wp-edunext-marketing-site' )
 				),
 				array(
+					'id' 			=> 'discovery_base_url',
+					'label'			=> __( 'Base domain for the open edX discovery service domain' , 'wp-edunext-marketing-site' ),
+					'description'	=> __( "The url where all your courses discovery API's are located.", 'wp-edunext-marketing-site' ),
+					'type'			=> 'text',
+					'default'		=> '',
+					'placeholder'	=> __( 'http://localhost:18381', 'wp-edunext-marketing-site' )
+				),
+				array(
 					'id' 			=> 'button_class_generic',
 					'label'			=> __( 'CSS classes for the buttons ' , 'wp-edunext-marketing-site' ),
 					'description'	=> __( 'You can override the specific buttons in the Enrollment tab' ),
@@ -170,6 +178,15 @@ class WP_eduNEXT_Marketing_Site_Settings {
 					'description'		=> __( 'Normally you don\'t need to change it.', 'wp-edunext-marketing-site' ),
 					'type'				=> 'text',
 					'default'			=> '/api/enrollment/v1/',
+					'placeholder'		=> __( '', 'wp-edunext-marketing-site' ),
+					'advanced_setting' 	=> true
+				),
+				array(
+					'id' 				=> 'discovery_course_runs_api_location',
+					'label'				=> __( 'Course runs API Location for discovery service' , 'wp-edunext-marketing-site' ),
+					'description'		=> __( 'Normally you don\'t need to change it.', 'wp-edunext-marketing-site' ),
+					'type'				=> 'text',
+					'default'			=> '/api/v1/course_runs/',
 					'placeholder'		=> __( '', 'wp-edunext-marketing-site' ),
 					'advanced_setting' 	=> true
 				),

--- a/includes/class-wp-edunext-marketing-site.php
+++ b/includes/class-wp-edunext-marketing-site.php
@@ -107,6 +107,7 @@ class WP_eduNEXT_Marketing_Site {
 		// Load shortcodes
 		add_action( 'wp_enqueue_scripts', array( $this, 'enroll_integration_scripts' ), 10 );
 		add_shortcode( 'edunext_enroll_button', array( $this, 'edunext_enroll_button' ) );
+		add_shortcode( 'discovery_course_runs', array( $this, 'discovery_course_runs' ) );
 
 		// Helpful tips for users using the shortcode
 		add_action( 'add_meta_boxes', array( $this, 'add_shortcode_help_meta_box') );
@@ -174,6 +175,9 @@ class WP_eduNEXT_Marketing_Site {
 	public function enqueue_styles () {
 		wp_register_style( $this->_token . '-frontend', esc_url( $this->assets_url ) . 'css/frontend.css', array(), $this->_version );
 		wp_enqueue_style( $this->_token . '-frontend' );
+
+		wp_register_style( $this->_token . '-discoveryCourseRunCards', esc_url( $this->assets_url ) . 'css/discoveryCourseRunCards.css', array(), $this->_version );
+		wp_enqueue_style( $this->_token . '-discoveryCourseRunCards' );
 	} // End enqueue_styles ()
 
 	/**
@@ -217,6 +221,7 @@ class WP_eduNEXT_Marketing_Site {
 	 */
 	public function enroll_integration_scripts ( $hook = '' ) {
 		wp_register_script( 'edunext_enroll_button', esc_url( $this->assets_url ) . 'js/edunextEnrollButton' . $this->script_suffix . '.js' , array( 'jquery', 'edunext_commons' ), $this->_version );
+		wp_register_script( 'discovery_course_runs', esc_url( $this->assets_url ) . 'js/discoveryCourseRunCards' . $this->script_suffix . '.js' , array( 'jquery', 'edunext_commons' ), $this->_version );
 	} // End enroll_integration_scripts ()
 
 	/**
@@ -232,7 +237,9 @@ class WP_eduNEXT_Marketing_Site {
 				'user_info_cookie_name' => get_option('wpt_user_info_cookie_name'),
 				'is_loggedin_cookie_name' => get_option('wpt_is_logged_in_cookie_name'),
 				'lms_base_url' => get_option('wpt_lms_base_url'),
+				'discovery_base_url' => get_option('wpt_discovery_base_url'),
 				'enrollment_api_location' => get_option('wpt_enrollment_api_location', '/api/enrollment/v1/'),
+				'discovery_course_runs_api_location' => get_option('wpt_discovery_course_runs_api_location', '/api/v1/course_runs/'),
 				'user_enrollment_url' => get_option('wpt_user_enrollment_url', '/register?course_id=%course_id%&enrollment_action=enroll'),
 				'course_has_not_started_url' => get_option('wpt_course_has_not_started_url', '/dashboard'),
 		));
@@ -300,6 +307,30 @@ class WP_eduNEXT_Marketing_Site {
 		return "<div class=\"ednx-enroll-button-js\" style=\"display:none\" data-course-id=\"${course_id}\" data-settings=\"${short_id}\"><span>" . $course_id . "</span></div>";
 
 	} // End edunext_enroll_button ()
+	public function discovery_course_runs ( $atts ) {
+		// How to use: [discovery_course_runs]
+
+		// Attributes
+		STATIC $unique_id = 1;
+		$short_id ='DiscoveryCourseRun' . $unique_id++;
+
+		$atts = shortcode_atts(
+			array(
+				'course_id' => '',
+			),
+			$atts,
+			'discovery_course_runs'
+		);
+
+		$this->enqueue_commons_script();
+		wp_enqueue_script( 'discovery_course_runs' );
+		wp_localize_script( 'discovery_course_runs', $short_id, $atts );
+
+		$course_id = $atts['course_id'];
+
+		return "<div class=\"discovery-course-runs-js\" style=\"display:none\" data-course-id=\"${course_id}\" data-settings=\"${short_id}\"><span>" . $course_id . "</span></div>";
+
+	} // End discovery_course_runs ()
 
 	public function add_shortcode_help_meta_box()
 	{


### PR DESCRIPTION
**Dependency:** Enable `CORS`  in course discovery (https://github.com/zubair-arbi/course-discovery/pull/1)

**Changes:**

1. Update eduNEXT Wordpress plugin (https://wordpress.org/plugins/edunext-openedx-integrator/) to allow basic configuration needed for communication with discovery service, introduced following two new settings variables:
```
Base domain for the open edX discovery service domain: http://localhost:18381
Course runs API Location for discovery service: /api/v1/course_runs/
```
2. Add a short code notation “discovery_course_runs“ to render courses in form of cards,
Example usage:
```
[discovery_course_runs]
```

**Wordpress plugin configuration:**

<img width="1235" alt="screen shot 2019-02-27 at 9 23 44 pm" src="https://user-images.githubusercontent.com/5072991/53505654-1d453d00-3ad6-11e9-8540-2589f5a3ff37.png">

**Example usage of short code notation `[discovery_course_runs]`:**

<img width="1240" alt="screen shot 2019-02-27 at 9 24 15 pm" src="https://user-images.githubusercontent.com/5072991/53505678-2b935900-3ad6-11e9-9ca1-2513abf6c108.png">

**Course runs API from Discovery service response:**

<img width="758" alt="screen shot 2019-02-27 at 9 28 09 pm" src="https://user-images.githubusercontent.com/5072991/53505917-b2483600-3ad6-11e9-8272-9338294c5257.png">

**Output to users _(all course runs from discovery service API `http://localhost:18381/api/v1/course_runs/` turned into cards)_:**
<img width="1236" alt="screen shot 2019-02-27 at 9 24 33 pm" src="https://user-images.githubusercontent.com/5072991/53505721-42d24680-3ad6-11e9-917a-2e273fde8301.png">



